### PR TITLE
fix: Update TC Mexico date and sort events by startDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
-# cuscontest-scoreboard
-Cuscontest Scoreboard
+# Cuscontest Scoreboard
+
+Sitio web de Competitive Programming UNSAAC para scoreboards y eventos de programación competitiva.
+
+Desplegado con GitHub Pages desde `docs/`.
+
+## Configuración
+
+Todo se gestiona en `docs/config.js`.
+
+### Eventos
+
+```javascript
+{ name: "Evento", url: "https://...", logo: "logo.png", startDate: "2026-08-03T09:00:00-05:00", endDate: "2026-08-15T18:00:00-05:00" },
+```
+
+- `logo`: archivo en `docs/img/`
+- Fechas en formato ISO 8601 con timezone (`-05:00` para Perú)
+- Se ordenan automáticamente por `startDate`
+- Solo se muestran los próximos (máximo: `scoreboardGrid.maxEvents`)
+
+### Scoreboards
+
+```javascript
+{ name: "Cuscontest XXVI", year: 2026, url: "https://codeforces.com/gym/...", platform: "Codeforces" },
+```
+
+Para scoreboards estáticos (DOMjudge exportado), crear carpeta `docs/cuscontest-xxvi/` y usar URL relativa:
+
+```javascript
+{ name: "Cuscontest XXVI", year: 2026, url: "./cuscontest-xxvi/index.html", platform: "DOMjudge" },
+```
+
+### Plataformas
+
+El campo `platform` muestra un ícono en la tarjeta. Mapeo en `docs/route.js`:
+
+```javascript
+const platformIcons = {
+  "Codeforces": "./img/codeforces.png",
+  "OmegaUp": "./img/omegaup.png",
+  "DOMjudge": "./img/domjudge.svg",
+};
+```
+
+Para nueva plataforma: agregar ícono en `docs/img/` y entrada en `platformIcons`.
+
+### Navegación
+
+```javascript
+pages: [
+  { name: "Scoreboards", url: "./index.html" },
+  { name: "Eventos", url: "./events.html" },
+  { name: "Dropdown", dropdown: [
+    { name: "Enlace", url: "https://..." },
+  ]},
+],
+```
+
+## Desarrollo Local
+
+Abrir `docs/index.html` en el navegador.

--- a/docs/config.js
+++ b/docs/config.js
@@ -44,7 +44,7 @@ const siteConfig = {
 
   events: [
     { name: "Training Camp Medellín 2026", url: "https://tcmedellin.com/", logo: "tcmedellin.png", startDate: "2026-06-29T09:00:00-05:00", endDate: "2026-07-10T18:00:00-05:00" },
-    { name: "Training Camp Mexico 2026", url: "https://icpc.global/regionals/finder/TCMX-2027", logo: "tcmexico.png", startDate: "2026-07-06T09:00:00-05:00", endDate: "2026-07-18T18:00:00-05:00" },
+    { name: "Training Camp Mexico 2026", url: "https://icpc.global/regionals/finder/TCMX-2027", logo: "tcmexico.png", startDate: "2026-08-03T09:00:00-05:00", endDate: "2026-08-15T18:00:00-05:00" },
     { name: "Training Camp UCSP 2026", url: "https://dc.ucsp.edu.pe/eventos/2do-training-camp-ucsp/", logo: "ucsp.png", startDate: "2026-07-13T09:00:00-05:00", endDate: "2026-07-17T18:00:00-05:00" },
     { name: "Training Camp Argentina 2026", url: "https://aapc.org.ar/tc/", logo: "tcarg.png", startDate: "2026-07-20T09:00:00-05:00", endDate: "2026-07-31T18:00:00-05:00" },
     { name: "Cuscontest XXV", url: "https://www.facebook.com/ACMUNSAAC", logo: "logo.png", startDate: "2026-08-07T09:00:00-05:00", endDate: "2026-08-07T14:00:00-05:00" },

--- a/docs/events.html
+++ b/docs/events.html
@@ -162,6 +162,7 @@
         const events = siteConfig.events
           .map((e, i) => ({ ...e, id: i + 1 }))
           .filter(e => new Date(e.endDate).getTime() > now)
+          .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
           .slice(0, siteConfig.scoreboardGrid.maxEvents);
 
         const spanishDays = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];


### PR DESCRIPTION
- Change Training Camp Mexico 2026 start to Aug 3 (was Jul 6)
- Sort events chronologically when rendering in events.html
- Rewrite README with concise configuration guide